### PR TITLE
Update from wikimedia/ip-set 4.0 to wikimedia/ip-utils 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "rtckit/ficore": "0.0.4",
         "rtckit/sip": "^0.7",
         "symfony/yaml": "^6.3",
-        "wikimedia/ip-set": "^4.0"
+        "wikimedia/ip-utils": "^5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
The wikimedia/ip-set package was deprecated. The IPSet class remains compatible and is now included in wikimedia/ip-utils.

See also https://packagist.org/packages/wikimedia/ip-utils and https://packagist.org/packages/wikimedia/ip-set